### PR TITLE
URL Cleanup

### DIFF
--- a/src/test/java/io/pivotal/stubrunner/CfStubRunnerBootApplicationTests.java
+++ b/src/test/java/io/pivotal/stubrunner/CfStubRunnerBootApplicationTests.java
@@ -6,7 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(properties = {"stubrunner.repositoryRoot=http://foo", "stubrunner.username=foo", "stubrunner.password=bar"})
+@SpringBootTest(properties = {"stubrunner.repositoryRoot=https://foo", "stubrunner.username=foo", "stubrunner.password=bar"})
 public class CfStubRunnerBootApplicationTests {
 
 	@Test


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://foo (UnknownHostException) with 1 occurrences migrated to:  
  https://foo ([https](https://foo) result UnknownHostException).